### PR TITLE
Add support for Wisconsin

### DIFF
--- a/src/LandCover.js
+++ b/src/LandCover.js
@@ -17,6 +17,7 @@ export class LandCoverServer {
       geometry: position,
       geometryType: 'esriGeometryPoint',
       inSR: 4326,
+      outSR: this.spatialReference,
       spatialRel: 'esriSpatialRelIntersects',
       f: 'pjson',
       returnGeometry: false,
@@ -36,6 +37,7 @@ export class LandCoverServer {
       geometry: position,
       geometryType: 'esriGeometryPoint',
       inSR: 4326,
+      outSR: this.spatialReference,
       spatialRel: 'esriSpatialRelIntersects',
       f: 'pjson',
       distance: buffer,
@@ -60,7 +62,7 @@ export class LandCoverServer {
   }
 
   coverType(feature) {
-    return feature.attributes[this.coverFieldName];
+    return feature.attributes[this.coverFieldName].toLowerCase();
   }
 
   async project(position) {
@@ -130,7 +132,53 @@ export class IllinoisLandCoverServer extends LandCoverServer {
         ['ti', 'forest']
       ]
     );
-    const landCode = feature.attributes[this.coverFieldName];
+    const landCode = feature.attributes[this.coverFieldName].toLowerCase();
     return landLabels.get(landCode);
+  }
+}
+
+
+export class WisconsinLandCoverServer extends LandCoverServer {
+  constructor(baseURL, coverFieldName, spatialReference) {
+    super(baseURL, coverFieldName, spatialReference);
+    this.waterFieldName = 'LUC_LEVEL_2_CODE';
+    this.outFields = [this.coverFieldName, this.waterFieldName];
+  }
+
+  coverType(feature) {
+    const landLabels = {
+      1: "place home to white spruce, balsam fir, tamarack, white cedar, white birch, and aspen",
+      2: "place home to beech, hemlock, sugar maple, yellow birch, white pine, and red pine",
+      3: "place home to hemlock, sugar maple, yellow birch, white pine, and red pine",
+      4: "place home to sugar maple, yellow birch, white pine, and red pine",
+      5: "place home to white pine and red pine",
+      6: "oak forest and barrens, including jack pine and Hill's scrub oak",
+      7: "place home to aspen, white birch, and pine",
+      8: "place home to beech, sugar maple, basswood, red oak, white oak, and black oak",
+      9: "place home to sugar maple, basswood, red oak, white oak, and black oak",
+      10: "place home to white oak, black oak, and bur oak",
+      11: "oak opening, including bur oak, white oak, and black oak",
+      12: "prairie",
+      13: "brushland",
+      14: "swamp with conifers, including white cedar, black spruce, tamarack, and hemlock",
+      15: "lowland with hardwoods, including willow, soft maple, box elder, ash, elm, cottonwood, and river birch",
+      16: "marsh and sedge meadow, wet prairie, and lowland shrubs",
+      99: "place with unknown vegetation cover",
+      0: "body of water", // should fall through to those below
+    }
+    const waterLabels = {
+      // Adapted from https://www.arcgis.com/home/item.html?id=b172c55a0ebb43a19886a4eb57bc5292
+      51: "stream or canal",
+      52: "lake",
+      53: "reservoir",
+    }
+    const landCode = feature.attributes[this.coverFieldName];
+    let label;
+    if (landCode === 0) {
+      label = waterLabels[feature.attributes[this.waterFieldName]];
+    } else {
+      label = landLabels[landCode]
+    }
+    return label;
   }
 }

--- a/src/Text.js
+++ b/src/Text.js
@@ -8,8 +8,8 @@ class Text {
   }
 
   currentCover(coverType) {
-    this.currentCoverType = coverType.toLowerCase();
-    this.main.innerHTML = `<p id='location'>This was a <strong>${coverType.toLowerCase()}</strong>.</p>`;
+    this.currentCoverType = coverType;
+    this.main.innerHTML = `<p id='location'>This was a <strong>${coverType}</strong>.</p>`;
     this.copyEdit();
   }
 
@@ -66,7 +66,7 @@ class Text {
       let humanDistance;
       if (idx === 0) {
         if (distance < 0.0625) {
-          sentence = `There was a ${cover.coverType.toLowerCase()} just to the ${cover.direction}`;
+          sentence = `There was a ${cover.coverType} just to the ${cover.direction}`;
         } else {
           if (distance > 0.9375) {
             humanDistance = 'a mile';
@@ -76,23 +76,23 @@ class Text {
           sentence = sentencePatterns.sample()(
             cover.direction,
             humanDistance,
-            cover.coverType.toLowerCase()
+            cover.coverType
           );
         }
       } else if (idx < (covers.length - 1)) {
         if (distance > 0.9375) {
-          sentence += `, a ${cover.coverType.toLowerCase()} in about a mile`;
+          sentence += `, a ${cover.coverType} in about a mile`;
         } else if (distance < 0.0625) {
-          sentence += `, a ${cover.coverType.toLowerCase()} very close by`;
+          sentence += `, a ${cover.coverType} very close by`;
         } else {
-          sentence += `, a ${cover.coverType.toLowerCase()} in about ${Text.humanFractions(distance)} of a mile`;
+          sentence += `, a ${cover.coverType} in about ${Text.humanFractions(distance)} of a mile`;
         }
       } else if (distance > 0.9375) {
-        sentence += ` and a ${cover.coverType.toLowerCase()} in about a mile`;
+        sentence += ` and a ${cover.coverType} in about a mile`;
       } else if (distance < 0.0625) {
-        sentence += ` and a ${cover.coverType.toLowerCase()} very close by`;
+        sentence += ` and a ${cover.coverType} very close by`;
       } else {
-        sentence += ` and a ${cover.coverType.toLowerCase()} in about ${Text.humanFractions(distance)} of a mile`;
+        sentence += ` and a ${cover.coverType} in about ${Text.humanFractions(distance)} of a mile`;
       }
     }
     return sentence;

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { LandCoverServer, IllinoisLandCoverServer } from './LandCover.js';
+import { LandCoverServer, IllinoisLandCoverServer, WisconsinLandCoverServer } from './LandCover.js';
 import Text from './Text.js';
 
 const stateConfigs = new Map(
@@ -16,7 +16,14 @@ const stateConfigs = new Map(
      spatialReference: 3857,
      source: 'Data from the Michigan State University\'s "<a href="https://mnfi.anr.msu.edu/resources/vegetation-circa-1800">Vegetation circa 1800</a>".'
 
-   }]
+    }],
+    ['Wisconsin', {
+      Class: WisconsinLandCoverServer,
+      baseURL: 'https://dnrmaps.wi.gov/arcgis/rest/services/DW_Map_Dynamic/EN_Forest_Land_Cover_WTM_Ext/MapServer/1/query?',
+      coverFieldName: 'VEG_TYPE_CODE',
+      spatialReference: 3857,
+      source: 'Data from the Wisconsin Department of Natural Resources\'s "<a href="https://data-wi-dnr.opendata.arcgis.com/datasets/3e952715b0d549c39cd8e26b4b274a0c_1?geometry=-108.180%2C42.004%2C-71.266%2C47.461">Original Vegetation Polygons</a>".'
+    }]
   ]
 );
 

--- a/whatwashere.html
+++ b/whatwashere.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="utf-8">
 </head>
-<body id='main' onload='getLocation()''>
+<body id='main' onload='getLocation()'>
   <div id='content'>
   </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js" integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous"></script>


### PR DESCRIPTION
Utilizes the [DNR's GIS service](https://data-wi-dnr.opendata.arcgis.com/datasets/3e952715b0d549c39cd8e26b4b274a0c_1?geometry=-108.180%2C42.004%2C-71.266%2C47.461) you found. This service outputs numeric codes, and uses a couple CSV files as lookup tables. I hard coded the lookup into the JS and special cased Wisconsin. Happy to redo that if you'd prefer it done a different way.

The DNR also uses two separate fields in the GIS response to get the full information -- one field (`VEG_TYPE_CODE`) gives you a vegetation code, but if that code is `0` then that means it's a body of water and you're supposed to look at the `LUC_LEVEL_2_CODE` field to determine lake vs stream vs reservoir. I decided to punt on that for now as it significantly reduced the generalizability of the code in `LandCover.js`.